### PR TITLE
fix module name in go starter

### DIFF
--- a/compiled_starters/go/go.mod
+++ b/compiled_starters/go/go.mod
@@ -6,7 +6,7 @@
 //
 // DON'T EDIT THIS!
 
-module github.com/codecrafters-io/grep-starter-go
+module github.com/codecrafters-io/bittorrent-starter-go
 
 go 1.16
 

--- a/solutions/go/01-bencode-string/code/go.mod
+++ b/solutions/go/01-bencode-string/code/go.mod
@@ -6,7 +6,7 @@
 //
 // DON'T EDIT THIS!
 
-module github.com/codecrafters-io/grep-starter-go
+module github.com/codecrafters-io/bittorrent-starter-go
 
 go 1.16
 

--- a/starter_templates/go/go.mod
+++ b/starter_templates/go/go.mod
@@ -6,7 +6,7 @@
 //
 // DON'T EDIT THIS!
 
-module github.com/codecrafters-io/grep-starter-go
+module github.com/codecrafters-io/bittorrent-starter-go
 
 go 1.16
 


### PR DESCRIPTION
the module name needs to be corrected
i'm sure it has other implications, for example I see `compiled_starters/`
not sure how everything is linked together so putting up for review