### PR TITLE
add hex crate for rust

### DIFF
--- a/compiled_starters/rust/Cargo.lock
+++ b/compiled_starters/rust/Cargo.lock
@@ -127,6 +127,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "clap",
+ "hex",
  "regex",
  "reqwest",
  "serde",
@@ -434,6 +435,12 @@ name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"

--- a/compiled_starters/rust/Cargo.toml
+++ b/compiled_starters/rust/Cargo.toml
@@ -22,6 +22,7 @@ edition = "2021"
 anyhow = "1.0.68"                                                  # error handling
 bytes = "1.3.0"                                                    # helps wrap responses from reqwest
 clap = { version = "4.0.32", features = ["derive"]}                # creating a cli
+hex = "0.4.3"
 regex = "1"                                                        # for regular expressions
 reqwest = { version = "0.11.18", features = ["json", "blocking"] } # http requests
 serde = { version = "1.0.136", features = ["derive"] }             # for json mangling

--- a/solutions/rust/01-bencode-string/code/Cargo.lock
+++ b/solutions/rust/01-bencode-string/code/Cargo.lock
@@ -127,6 +127,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "clap",
+ "hex",
  "regex",
  "reqwest",
  "serde",
@@ -434,6 +435,12 @@ name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"

--- a/solutions/rust/01-bencode-string/code/Cargo.toml
+++ b/solutions/rust/01-bencode-string/code/Cargo.toml
@@ -22,6 +22,7 @@ edition = "2021"
 anyhow = "1.0.68"                                                  # error handling
 bytes = "1.3.0"                                                    # helps wrap responses from reqwest
 clap = { version = "4.0.32", features = ["derive"]}                # creating a cli
+hex = "0.4.3"
 regex = "1"                                                        # for regular expressions
 reqwest = { version = "0.11.18", features = ["json", "blocking"] } # http requests
 serde = { version = "1.0.136", features = ["derive"] }             # for json mangling

--- a/starter_templates/rust/Cargo.lock
+++ b/starter_templates/rust/Cargo.lock
@@ -127,6 +127,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "clap",
+ "hex",
  "regex",
  "reqwest",
  "serde",
@@ -434,6 +435,12 @@ name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"

--- a/starter_templates/rust/Cargo.toml
+++ b/starter_templates/rust/Cargo.toml
@@ -22,6 +22,7 @@ edition = "2021"
 anyhow = "1.0.68"                                                  # error handling
 bytes = "1.3.0"                                                    # helps wrap responses from reqwest
 clap = { version = "4.0.32", features = ["derive"]}                # creating a cli
+hex = "0.4.3"
 regex = "1"                                                        # for regular expressions
 reqwest = { version = "0.11.18", features = ["json", "blocking"] } # http requests
 serde = { version = "1.0.136", features = ["derive"] }             # for json mangling


### PR DESCRIPTION
from course feedback:
![Screen Shot 2023-09-21 at 22 04 03](https://github.com/codecrafters-io/build-your-own-bittorrent/assets/33414/a23e21ba-ec78-4012-be88-0a39ba29848e)

the code needed to convert wasn't too bad:
```
pub fn to_hex_string(bytes: &[u8]) -> String {
    let mut s = String::new();
    for byte in bytes {
        s += format!("{:02x}", byte).as_str();
    }
    s
}
```
adding this for convenience, now they will be able to use `hex::encode(...)`

**Commands used:**
- cargo add hex
- docker compose run tester scripts/compile_and_test.sh courses/build-your-own-bittorrent rust