### PR TITLE
mark torrent files as binary in gitattributes

### DIFF
--- a/compiled_starters/c/.gitattributes
+++ b/compiled_starters/c/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.torrent binary

--- a/compiled_starters/cpp/.gitattributes
+++ b/compiled_starters/cpp/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.torrent binary

--- a/compiled_starters/csharp/.gitattributes
+++ b/compiled_starters/csharp/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.torrent binary

--- a/compiled_starters/go/.gitattributes
+++ b/compiled_starters/go/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.torrent binary

--- a/compiled_starters/java/.gitattributes
+++ b/compiled_starters/java/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.torrent binary

--- a/compiled_starters/javascript/.gitattributes
+++ b/compiled_starters/javascript/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.torrent binary

--- a/compiled_starters/python/.gitattributes
+++ b/compiled_starters/python/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.torrent binary

--- a/compiled_starters/ruby/.gitattributes
+++ b/compiled_starters/ruby/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.torrent binary

--- a/compiled_starters/rust/.gitattributes
+++ b/compiled_starters/rust/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.torrent binary

--- a/solutions/c/01-bencode-string/code/.gitattributes
+++ b/solutions/c/01-bencode-string/code/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.torrent binary

--- a/solutions/cpp/01-bencode-string/code/.gitattributes
+++ b/solutions/cpp/01-bencode-string/code/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.torrent binary

--- a/solutions/csharp/01-bencode-string/code/.gitattributes
+++ b/solutions/csharp/01-bencode-string/code/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.torrent binary

--- a/solutions/go/01-bencode-string/code/.gitattributes
+++ b/solutions/go/01-bencode-string/code/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.torrent binary

--- a/solutions/java/01-bencode-string/code/.gitattributes
+++ b/solutions/java/01-bencode-string/code/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.torrent binary

--- a/solutions/javascript/01-bencode-string/code/.gitattributes
+++ b/solutions/javascript/01-bencode-string/code/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.torrent binary

--- a/solutions/python/01-bencode-string/code/.gitattributes
+++ b/solutions/python/01-bencode-string/code/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.torrent binary

--- a/solutions/ruby/01-bencode-string/code/.gitattributes
+++ b/solutions/ruby/01-bencode-string/code/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.torrent binary

--- a/solutions/rust/01-bencode-string/code/.gitattributes
+++ b/solutions/rust/01-bencode-string/code/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.torrent binary

--- a/starter_templates/.gitattributes
+++ b/starter_templates/.gitattributes
@@ -1,2 +1,2 @@
 * text=auto
-*.torrent -diff
+*.torrent binary

--- a/starter_templates/.gitattributes
+++ b/starter_templates/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.torrent -diff


### PR DESCRIPTION
Received user feedback about pieces field in torrent files getting corrupted on Windows (unverified)

Setting torrent files as binary using instructions here:
https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#example

> Example
> Here's an example .gitattributes file. You can use it as a template for your repositories:
> 
> ```
> # Set the default behavior, in case people don't have core.autocrlf set.
> * text=auto
> 
> # Explicitly declare text files you want to always be normalized and converted
> # to native line endings on checkout.
> *.c text
> *.h text
> 
> # Declare files that will always have CRLF line endings on checkout.
> *.sln text eol=crlf
> 
> # Denote all files that are truly binary and should not be modified.
> *.png binary
> *.jpg binary
> ```
> You'll notice that files are matched—*.c, *.sln, *.png—, separated by a space, then given a setting—text, text eol=crlf, binary. We'll go over some possible settings below.
> 
> text=auto Git will handle the files in whatever way it thinks is best. This is a good default option.
> 
> text eol=crlf Git will always convert line endings to CRLF on checkout. You should use this for files that must keep CRLF endings, even on OSX or Linux.
> 
> text eol=lf Git will always convert line endings to LF on checkout. You should use this for files that must keep LF endings, even on Windows.
> 
> binary Git will understand that the files specified are not text, and it should not try to change them. The binary setting is also an alias for -text -diff.
> 