### PR TITLE
add github action to validate md5 of sample.torrent

### DIFF
--- a/.github/workflows/sample-torrent-md5-check.yml
+++ b/.github/workflows/sample-torrent-md5-check.yml
@@ -1,7 +1,11 @@
-name: MD5 Check
+name: MD5 Check on sample.torrent files
 
-on: [push, pull_request]
-  paths:
+on:
+  push:
+    paths:
+      - '**/sample.torrent'
+  pull_request:
+    paths:
       - '**/sample.torrent'
 
 jobs:

--- a/.github/workflows/sample-torrent-md5-check.yml
+++ b/.github/workflows/sample-torrent-md5-check.yml
@@ -1,6 +1,8 @@
 name: MD5 Check
 
 on: [push, pull_request]
+  paths:
+      - '**/sample.torrent'
 
 jobs:
   check-md5:

--- a/.github/workflows/sample-torrent-md5-check.yml
+++ b/.github/workflows/sample-torrent-md5-check.yml
@@ -1,4 +1,4 @@
-name: MD5 Check on sample.torrent files
+name: MD5 check on sample.torrent files
 
 on:
   push:

--- a/.github/workflows/sample-torrent-md5-check.yml
+++ b/.github/workflows/sample-torrent-md5-check.yml
@@ -1,0 +1,16 @@
+name: MD5 Check
+
+on: [push, pull_request]
+
+jobs:
+  check-md5:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Check sample.torrent MD5
+      run: |
+          find . -name "sample.torrent" | xargs -n1 shasum | awk '!/^32682077130437f19fb388813bca3355378b7621/ {print "Mismatching MD5 found: " $0; exit 1}'
+

--- a/starter_templates/sample.torrent
+++ b/starter_templates/sample.torrent
@@ -1,1 +1,1 @@
-ad8:announce55:http://bittorrent-test-tracker.codecrafters.io/announce10:created by13:mktorrent 1.14:infod6:lengthi92063e4:name10:sample.txt12:piece lengthi32768e6:pieces60:èvöz*ˆ†èókg&Ã¢—-n"uæ vfVsnÿµR­5ğ“zß‚¼	r'­šÌee
+d8:announce55:http://bittorrent-test-tracker.codecrafters.io/announce10:created by13:mktorrent 1.14:infod6:lengthi92063e4:name10:sample.txt12:piece lengthi32768e6:pieces60:èvöz*ˆ†èókg&Ã¢—-n"uæ vfVsnÿµR­5ğ“zß‚¼	r'­šÌee

--- a/starter_templates/sample.torrent
+++ b/starter_templates/sample.torrent
@@ -1,1 +1,1 @@
-d8:announce55:http://bittorrent-test-tracker.codecrafters.io/announce10:created by13:mktorrent 1.14:infod6:lengthi92063e4:name10:sample.txt12:piece lengthi32768e6:pieces60:èvöz*ˆ†èókg&Ã¢—-n"uæ vfVsnÿµR­5ğ“zß‚¼	r'­šÌee
+ad8:announce55:http://bittorrent-test-tracker.codecrafters.io/announce10:created by13:mktorrent 1.14:infod6:lengthi92063e4:name10:sample.txt12:piece lengthi32768e6:pieces60:èvöz*ˆ†èókg&Ã¢—-n"uæ vfVsnÿµR­5ğ“zß‚¼	r'­šÌee


### PR DESCRIPTION
This is to prevent modifications to `sample.torrent` going unnoticed
It checks every sample.torrent file in the repo and validates that each md5 is equal to `32682077130437f19fb388813bca3355378b7621`

FYI: It's my first Github Action :)