### PR TITLE
Clarify metadata extension ID requirement (#zh1 Receive metadata)

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -957,7 +957,7 @@ stages:
         - This will be 20, since this is a message implemented by an extension
       - payload (variable size)
           - extension message id (1 byte)
-            - This will be your peer's metadata extension ID, which it sent as part of the extension handshake
+            - This will be your peer's metadata extension ID, which you sent as part of the extension handshake
           - bencoded dictionary (variable size)
             - This dictionary will look like this: `{'msg_type': 1, 'piece': 0, 'total_size': XXXX}`
             - `msg_type` will be 1, since this is a `data` message


### PR DESCRIPTION
Membership feedback:

> "This will be your peer's metadata extension ID, which it sent as part of the extension handshake" This sounds like it should be using the peer's metadata ID, but they are in fact sending YOUR metadata id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the descriptive text for the metadata handshake process to more accurately indicate that the current entity sends the metadata extension ID during the exchange.
  - This change improves clarity in our communication guidelines without altering any public functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->