### PR TITLE
Link OpenSSL for C and C++

### DIFF
--- a/compiled_starters/c/CMakeLists.txt
+++ b/compiled_starters/c/CMakeLists.txt
@@ -6,4 +6,8 @@ file(GLOB_RECURSE SOURCE_FILES src/*.c src/*.h)
 
 set(CMAKE_C_STANDARD 23) # Enable the C23 standard
 
+find_package(OpenSSL REQUIRED)
+
 add_executable(bittorrent ${SOURCE_FILES})
+
+target_link_libraries(bittorrent PRIVATE OpenSSL::Crypto)

--- a/compiled_starters/cpp/CMakeLists.txt
+++ b/compiled_starters/cpp/CMakeLists.txt
@@ -6,4 +6,8 @@ set(CMAKE_CXX_STANDARD 23) # Enable the C++23 standard
 
 file(GLOB_RECURSE SOURCE_FILES src/*.cpp src/*.hpp)
 
+find_package(OpenSSL REQUIRED)
+
 add_executable(bittorrent ${SOURCE_FILES})
+
+target_link_libraries(bittorrent PRIVATE OpenSSL::Crypto)

--- a/solutions/c/01-ns2/code/CMakeLists.txt
+++ b/solutions/c/01-ns2/code/CMakeLists.txt
@@ -6,4 +6,8 @@ file(GLOB_RECURSE SOURCE_FILES src/*.c src/*.h)
 
 set(CMAKE_C_STANDARD 23) # Enable the C23 standard
 
+find_package(OpenSSL REQUIRED)
+
 add_executable(bittorrent ${SOURCE_FILES})
+
+target_link_libraries(bittorrent PRIVATE OpenSSL::Crypto)

--- a/solutions/cpp/01-ns2/code/CMakeLists.txt
+++ b/solutions/cpp/01-ns2/code/CMakeLists.txt
@@ -6,4 +6,8 @@ set(CMAKE_CXX_STANDARD 23) # Enable the C++23 standard
 
 file(GLOB_RECURSE SOURCE_FILES src/*.cpp src/*.hpp)
 
+find_package(OpenSSL REQUIRED)
+
 add_executable(bittorrent ${SOURCE_FILES})
+
+target_link_libraries(bittorrent PRIVATE OpenSSL::Crypto)

--- a/starter_templates/c/code/CMakeLists.txt
+++ b/starter_templates/c/code/CMakeLists.txt
@@ -6,4 +6,8 @@ file(GLOB_RECURSE SOURCE_FILES src/*.c src/*.h)
 
 set(CMAKE_C_STANDARD 23) # Enable the C23 standard
 
+find_package(OpenSSL REQUIRED)
+
 add_executable(bittorrent ${SOURCE_FILES})
+
+target_link_libraries(bittorrent PRIVATE OpenSSL::Crypto)

--- a/starter_templates/cpp/code/CMakeLists.txt
+++ b/starter_templates/cpp/code/CMakeLists.txt
@@ -6,4 +6,8 @@ set(CMAKE_CXX_STANDARD 23) # Enable the C++23 standard
 
 file(GLOB_RECURSE SOURCE_FILES src/*.cpp src/*.hpp)
 
+find_package(OpenSSL REQUIRED)
+
 add_executable(bittorrent ${SOURCE_FILES})
+
+target_link_libraries(bittorrent PRIVATE OpenSSL::Crypto)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build configuration to require and link against the OpenSSL Crypto library for all relevant C and C++ projects. This ensures cryptographic support is included during the build process. No changes to application features or user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->