### PR TITLE
Fix Ruby Dockerfile dependency (libssl3) issue

### DIFF
--- a/dockerfiles/ruby-3.3.Dockerfile
+++ b/dockerfiles/ruby-3.3.Dockerfile
@@ -4,7 +4,7 @@ FROM ruby:3.3-alpine
 # Required for installing the json/async gems
 RUN apk add --no-cache \
     build-base~=0.5 \
-    libssl3~=3.3 \
+    libssl3~=3.5 \
     readline-dev~=8.2 \
     zlib-dev~=1.3
 


### PR DESCRIPTION
Fix the same issue as:

https://github.com/codecrafters-io/build-your-own-redis/pull/312