### PR TITLE
CC-2189: Upgrade Rust to v1.94

### DIFF
--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -27,7 +27,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.93)` installed locally
+1. Ensure you have `cargo (1.94)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/compiled_starters/rust/codecrafters.yml
+++ b/compiled_starters/rust/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.93
-buildpack: rust-1.93
+# Available versions: rust-1.94
+buildpack: rust-1.94

--- a/dockerfiles/rust-1.94.Dockerfile
+++ b/dockerfiles/rust-1.94.Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM rust:1.94-trixie
+
+# Rebuild the container if these files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Cargo.toml,Cargo.lock"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs cargo build
+RUN .codecrafters/compile.sh

--- a/solutions/rust/01-ns2/code/README.md
+++ b/solutions/rust/01-ns2/code/README.md
@@ -27,7 +27,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.93)` installed locally
+1. Ensure you have `cargo (1.94)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/01-ns2/code/codecrafters.yml
+++ b/solutions/rust/01-ns2/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.93
-buildpack: rust-1.93
+# Available versions: rust-1.94
+buildpack: rust-1.94

--- a/starter_templates/rust/config.yml
+++ b/starter_templates/rust/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: cargo (1.93)
+  required_executable: cargo (1.94)
   user_editable_file: src/main.rs


### PR DESCRIPTION
CC-2189: Upgrade Rust to v1.94

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the Rust toolchain/buildpack version used for starters and CI execution, which can introduce new compiler/lint behavior and break existing solutions or dependencies. Risk is limited to Rust challenge environments and is straightforward to roll back.
> 
> **Overview**
> Upgrades the Rust starter and execution environment from **Rust 1.93 to 1.94** by updating the referenced `buildpack` in `codecrafters.yml` and the documented/required local `cargo` version in Rust READMEs and template config.
> 
> Adds a new `dockerfiles/rust-1.94.Dockerfile` (mirroring the prior 1.93 image) to provide the containerized build environment for the new toolchain version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 746c95df4e94e699c6465f7b35ad156ccfd1c758. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->