### PR TITLE
CC-2223 Add Scala starter

### DIFF
--- a/compiled_starters/scala/.codecrafters/compile.sh
+++ b/compiled_starters/scala/.codecrafters/compile.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+scala-cli package src/main/scala/ \
+  -q --power --assembly --force --server=false --scala-version=3.8.3 \
+  -o /tmp/codecrafters-build-bittorrent-scala

--- a/compiled_starters/scala/.codecrafters/run.sh
+++ b/compiled_starters/scala/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec java -jar /tmp/codecrafters-build-bittorrent-scala "$@"

--- a/compiled_starters/scala/.gitattributes
+++ b/compiled_starters/scala/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.torrent binary

--- a/compiled_starters/scala/.gitignore
+++ b/compiled_starters/scala/.gitignore
@@ -1,0 +1,17 @@
+out/
+.bloop/
+.metals/
+.vscode/
+.idea/
+.cursor/
+
+.bsp
+.scala-build
+dest/
+target/
+
+*/scoverage.coverage
+
+# ignore vim backup files
+*.sw[op]
+.DS_Store

--- a/compiled_starters/scala/README.md
+++ b/compiled_starters/scala/README.md
@@ -1,0 +1,35 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/bittorrent.png)
+
+This is a starting point for Scala solutions to the
+["Build Your Own BitTorrent" Challenge](https://app.codecrafters.io/courses/bittorrent/overview).
+
+In this challenge, you’ll build a BitTorrent client that's capable of parsing a
+.torrent file and downloading a file from a peer. Along the way, we’ll learn
+about how torrent files are structured, HTTP trackers, BitTorrent’s Peer
+Protocol, pipelining and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your BitTorrent implementation is in
+`src/main/scala/codecrafters_bittorrent/App.scala`. Study and uncomment the
+relevant code, and push your changes to pass the first stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+Time to move on to the next stage!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `scala-cli` installed locally
+1. Run `./your_program.sh` to run your program, which is implemented in
+   `src/main/scala/codecrafters_bittorrent/App.scala`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.

--- a/compiled_starters/scala/codecrafters.yml
+++ b/compiled_starters/scala/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the Scala version used to run your code
+# on Codecrafters.
+#
+# Available versions: scala-3.8
+buildpack: scala-3.8

--- a/compiled_starters/scala/sample.torrent
+++ b/compiled_starters/scala/sample.torrent
@@ -1,0 +1,1 @@
+d8:announce55:http://bittorrent-test-tracker.codecrafters.io/announce10:created by13:mktorrent 1.14:infod6:lengthi92063e4:name10:sample.txt12:piece lengthi32768e6:pieces60:èvöz*ˆ†èókg&Ã¢—-n"uæ vfVsnÿµR­5ğ“zß‚¼	r'­šÌee

--- a/compiled_starters/scala/src/main/scala/codecrafters_bittorrent/App.scala
+++ b/compiled_starters/scala/src/main/scala/codecrafters_bittorrent/App.scala
@@ -1,0 +1,32 @@
+//> using dep com.lihaoyi::ujson:4.4.3
+
+package codecrafters_bittorrent
+
+@main def main(args: String*): Unit =
+  if args.length < 2 then
+    println("Usage: your_program.sh <command> <args>")
+    sys.exit(1)
+
+  val command = args(0)
+
+  // You can use print statements as follows for debugging, they'll be visible when running tests.
+  System.err.println("Logs from your program will appear here!")
+
+  // TODO: Uncomment the code below to pass the first stage
+  // if command == "decode" then
+  //   val encodedStr = args(1)
+  //   val decodedStr = decodeBencode(encodedStr)
+  //   println(ujson.write(ujson.Str(decodedStr), indent = -1))
+
+// Examples:
+// - decodeBencode("5:hello") -> "hello"
+// - decodeBencode("10:hello12345") -> "hello12345"
+def decodeBencode(bencodedValue: String): String =
+  if bencodedValue.isEmpty then throw new IllegalArgumentException("Invalid encoded value")
+  if bencodedValue(0).isDigit then
+    val colonIdx = bencodedValue.indexOf(':')
+    if colonIdx < 0 then throw new IllegalArgumentException("Invalid encoded value")
+    bencodedValue.substring(colonIdx + 1)
+  else
+    println("Only strings are supported at the moment")
+    sys.exit(1)

--- a/compiled_starters/scala/your_program.sh
+++ b/compiled_starters/scala/your_program.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/compile.sh
+#
+# - Edit this to change how your program compiles locally
+# - Edit .codecrafters/compile.sh to change how your program compiles remotely
+(
+  cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  scala-cli package src/main/scala/ \
+    -q --power --assembly --force --server=false --scala-version=3.8.3 \
+    -o /tmp/codecrafters-build-bittorrent-scala
+)
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+exec java -jar /tmp/codecrafters-build-bittorrent-scala "$@"

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -78,6 +78,8 @@ languages:
   - slug: "python"
   - slug: "ruby"
   - slug: "rust"
+  - slug: "scala"
+    release_status: "beta"
   - slug: "zig"
     release_status: "beta"
   - slug: "typescript"

--- a/dockerfiles/scala-3.8.Dockerfile
+++ b/dockerfiles/scala-3.8.Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM eclipse-temurin:25-jdk-alpine-3.23
+
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+
+RUN apk add --no-cache --upgrade bash=5.3.3-r1 && \
+    curl -fsSL https://github.com/VirtusLab/scala-cli/releases/latest/download/scala-cli-x86_64-pc-linux-static.gz | gzip -d > /usr/local/bin/scala-cli && \
+    chmod +x /usr/local/bin/scala-cli
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+WORKDIR /app
+
+RUN .codecrafters/compile.sh

--- a/solutions/scala/01-ns2/code/.codecrafters/compile.sh
+++ b/solutions/scala/01-ns2/code/.codecrafters/compile.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+scala-cli package src/main/scala/ \
+  -q --power --assembly --force --server=false --scala-version=3.8.3 \
+  -o /tmp/codecrafters-build-bittorrent-scala

--- a/solutions/scala/01-ns2/code/.codecrafters/run.sh
+++ b/solutions/scala/01-ns2/code/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec java -jar /tmp/codecrafters-build-bittorrent-scala "$@"

--- a/solutions/scala/01-ns2/code/.gitattributes
+++ b/solutions/scala/01-ns2/code/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.torrent binary

--- a/solutions/scala/01-ns2/code/.gitignore
+++ b/solutions/scala/01-ns2/code/.gitignore
@@ -1,0 +1,17 @@
+out/
+.bloop/
+.metals/
+.vscode/
+.idea/
+.cursor/
+
+.bsp
+.scala-build
+dest/
+target/
+
+*/scoverage.coverage
+
+# ignore vim backup files
+*.sw[op]
+.DS_Store

--- a/solutions/scala/01-ns2/code/README.md
+++ b/solutions/scala/01-ns2/code/README.md
@@ -1,0 +1,35 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/bittorrent.png)
+
+This is a starting point for Scala solutions to the
+["Build Your Own BitTorrent" Challenge](https://app.codecrafters.io/courses/bittorrent/overview).
+
+In this challenge, you’ll build a BitTorrent client that's capable of parsing a
+.torrent file and downloading a file from a peer. Along the way, we’ll learn
+about how torrent files are structured, HTTP trackers, BitTorrent’s Peer
+Protocol, pipelining and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your BitTorrent implementation is in
+`src/main/scala/codecrafters_bittorrent/App.scala`. Study and uncomment the
+relevant code, and push your changes to pass the first stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+Time to move on to the next stage!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `scala-cli` installed locally
+1. Run `./your_program.sh` to run your program, which is implemented in
+   `src/main/scala/codecrafters_bittorrent/App.scala`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.

--- a/solutions/scala/01-ns2/code/codecrafters.yml
+++ b/solutions/scala/01-ns2/code/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the Scala version used to run your code
+# on Codecrafters.
+#
+# Available versions: scala-3.8
+buildpack: scala-3.8

--- a/solutions/scala/01-ns2/code/sample.torrent
+++ b/solutions/scala/01-ns2/code/sample.torrent
@@ -1,0 +1,1 @@
+d8:announce55:http://bittorrent-test-tracker.codecrafters.io/announce10:created by13:mktorrent 1.14:infod6:lengthi92063e4:name10:sample.txt12:piece lengthi32768e6:pieces60:èvöz*ˆ†èókg&Ã¢—-n"uæ vfVsnÿµR­5ğ“zß‚¼	r'­šÌee

--- a/solutions/scala/01-ns2/code/src/main/scala/codecrafters_bittorrent/App.scala
+++ b/solutions/scala/01-ns2/code/src/main/scala/codecrafters_bittorrent/App.scala
@@ -1,0 +1,28 @@
+//> using dep com.lihaoyi::ujson:4.4.3
+
+package codecrafters_bittorrent
+
+@main def main(args: String*): Unit =
+  if args.length < 2 then
+    println("Usage: your_program.sh <command> <args>")
+    sys.exit(1)
+
+  val command = args(0)
+
+  if command == "decode" then
+    val encodedStr = args(1)
+    val decodedStr = decodeBencode(encodedStr)
+    println(ujson.write(ujson.Str(decodedStr), indent = -1))
+
+// Examples:
+// - decodeBencode("5:hello") -> "hello"
+// - decodeBencode("10:hello12345") -> "hello12345"
+def decodeBencode(bencodedValue: String): String =
+  if bencodedValue.isEmpty then throw new IllegalArgumentException("Invalid encoded value")
+  if bencodedValue(0).isDigit then
+    val colonIdx = bencodedValue.indexOf(':')
+    if colonIdx < 0 then throw new IllegalArgumentException("Invalid encoded value")
+    bencodedValue.substring(colonIdx + 1)
+  else
+    println("Only strings are supported at the moment")
+    sys.exit(1)

--- a/solutions/scala/01-ns2/code/your_program.sh
+++ b/solutions/scala/01-ns2/code/your_program.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/compile.sh
+#
+# - Edit this to change how your program compiles locally
+# - Edit .codecrafters/compile.sh to change how your program compiles remotely
+(
+  cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
+  scala-cli package src/main/scala/ \
+    -q --power --assembly --force --server=false --scala-version=3.8.3 \
+    -o /tmp/codecrafters-build-bittorrent-scala
+)
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+exec java -jar /tmp/codecrafters-build-bittorrent-scala "$@"

--- a/solutions/scala/01-ns2/diff/src/main/scala/codecrafters_bittorrent/App.scala.diff
+++ b/solutions/scala/01-ns2/diff/src/main/scala/codecrafters_bittorrent/App.scala.diff
@@ -1,0 +1,37 @@
+@@ -1,32 +1,28 @@
+ //> using dep com.lihaoyi::ujson:4.4.3
+
+ package codecrafters_bittorrent
+
+ @main def main(args: String*): Unit =
+   if args.length < 2 then
+     println("Usage: your_program.sh <command> <args>")
+     sys.exit(1)
+
+   val command = args(0)
+
+-  // You can use print statements as follows for debugging, they'll be visible when running tests.
+-  System.err.println("Logs from your program will appear here!")
+-
+-  // TODO: Uncomment the code below to pass the first stage
+-  // if command == "decode" then
+-  //   val encodedStr = args(1)
+-  //   val decodedStr = decodeBencode(encodedStr)
+-  //   println(ujson.write(ujson.Str(decodedStr), indent = -1))
++  if command == "decode" then
++    val encodedStr = args(1)
++    val decodedStr = decodeBencode(encodedStr)
++    println(ujson.write(ujson.Str(decodedStr), indent = -1))
+
+ // Examples:
+ // - decodeBencode("5:hello") -> "hello"
+ // - decodeBencode("10:hello12345") -> "hello12345"
+ def decodeBencode(bencodedValue: String): String =
+   if bencodedValue.isEmpty then throw new IllegalArgumentException("Invalid encoded value")
+   if bencodedValue(0).isDigit then
+     val colonIdx = bencodedValue.indexOf(':')
+     if colonIdx < 0 then throw new IllegalArgumentException("Invalid encoded value")
+     bencodedValue.substring(colonIdx + 1)
+   else
+     println("Only strings are supported at the moment")
+     sys.exit(1)

--- a/starter_templates/scala/code/.codecrafters/compile.sh
+++ b/starter_templates/scala/code/.codecrafters/compile.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+scala-cli package src/main/scala/ \
+  -q --power --assembly --force --server=false --scala-version=3.8.3 \
+  -o /tmp/codecrafters-build-bittorrent-scala

--- a/starter_templates/scala/code/.codecrafters/run.sh
+++ b/starter_templates/scala/code/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec java -jar /tmp/codecrafters-build-bittorrent-scala "$@"

--- a/starter_templates/scala/code/.gitignore
+++ b/starter_templates/scala/code/.gitignore
@@ -1,0 +1,17 @@
+out/
+.bloop/
+.metals/
+.vscode/
+.idea/
+.cursor/
+
+.bsp
+.scala-build
+dest/
+target/
+
+*/scoverage.coverage
+
+# ignore vim backup files
+*.sw[op]
+.DS_Store

--- a/starter_templates/scala/code/src/main/scala/codecrafters_bittorrent/App.scala
+++ b/starter_templates/scala/code/src/main/scala/codecrafters_bittorrent/App.scala
@@ -1,0 +1,32 @@
+//> using dep com.lihaoyi::ujson:4.4.3
+
+package codecrafters_bittorrent
+
+@main def main(args: String*): Unit =
+  if args.length < 2 then
+    println("Usage: your_program.sh <command> <args>")
+    sys.exit(1)
+
+  val command = args(0)
+
+  // You can use print statements as follows for debugging, they'll be visible when running tests.
+  System.err.println("Logs from your program will appear here!")
+
+  // TODO: Uncomment the code below to pass the first stage
+  // if command == "decode" then
+  //   val encodedStr = args(1)
+  //   val decodedStr = decodeBencode(encodedStr)
+  //   println(ujson.write(ujson.Str(decodedStr), indent = -1))
+
+// Examples:
+// - decodeBencode("5:hello") -> "hello"
+// - decodeBencode("10:hello12345") -> "hello12345"
+def decodeBencode(bencodedValue: String): String =
+  if bencodedValue.isEmpty then throw new IllegalArgumentException("Invalid encoded value")
+  if bencodedValue(0).isDigit then
+    val colonIdx = bencodedValue.indexOf(':')
+    if colonIdx < 0 then throw new IllegalArgumentException("Invalid encoded value")
+    bencodedValue.substring(colonIdx + 1)
+  else
+    println("Only strings are supported at the moment")
+    sys.exit(1)

--- a/starter_templates/scala/config.yml
+++ b/starter_templates/scala/config.yml
@@ -1,0 +1,3 @@
+attributes:
+  required_executable: scala-cli
+  user_editable_file: src/main/scala/codecrafters_bittorrent/App.scala


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new Scala buildpack and packaging pipeline (Docker + `scala-cli` assembly), which may affect CI/build caching and runtime behavior for the new language path. Existing languages are largely untouched aside from registering Scala in `course-definition.yml`.
> 
> **Overview**
> Adds **Scala (beta)** support for the BitTorrent course by registering `scala` in `course-definition.yml` and introducing a `scala-3.8` buildpack Dockerfile that installs `scala-cli` and runs `.codecrafters/compile.sh`.
> 
> Introduces Scala starter assets (compiled starter + template) including `.codecrafters/compile.sh`/`run.sh`, local `your_program.sh`, ignore/attributes files, `codecrafters.yml`, and a sample `.torrent`. Adds an initial Scala `App.scala` with a stubbed bencode decoder in the starter template and a stage-1 solution that enables the `decode` command (with an accompanying diff file).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7e0ab1f3e7016b86e713eeab7965c83e8078086. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->