### PR TITLE
CC-2188: Upgrade Scala to v3.8

### DIFF
--- a/dockerfiles/scala-3.8.Dockerfile
+++ b/dockerfiles/scala-3.8.Dockerfile
@@ -3,7 +3,8 @@ FROM eclipse-temurin:25-jdk-alpine-3.23
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
-RUN apk add --no-cache --upgrade bash=5.3.3-r1 && \
+# hadolint ignore=DL3018
+RUN apk add --no-cache --upgrade bash curl && \
     curl -fsSL https://github.com/VirtusLab/scala-cli/releases/latest/download/scala-cli-x86_64-pc-linux-static.gz | gzip -d > /usr/local/bin/scala-cli && \
     chmod +x /usr/local/bin/scala-cli
 


### PR DESCRIPTION
CC-2188: Upgrade Scala to v3.8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build change limited to the Scala 3.8 Docker image; it only adjusts APK package installation (adds `curl`, removes the pinned `bash` version), which may affect image reproducibility but not application logic.
> 
> **Overview**
> Updates the Scala 3.8 Docker image to install `curl` via `apk` (and suppresses `hadolint` `DL3018`) while removing the explicit `bash` version pin, relying on repository-provided package versions.
> 
> The Scala CLI download step remains the same, but the image build now depends on unpinned `bash`/`curl` versions from Alpine.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40cfb1bb94fa7e89aa213557ace2467ec125f764. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->