### PR TITLE
CC-2191: Upgrade Ruby to v4

### DIFF
--- a/compiled_starters/ruby/Gemfile.lock
+++ b/compiled_starters/ruby/Gemfile.lock
@@ -6,10 +6,10 @@ PLATFORMS
   aarch64-linux-musl
   arm64-darwin-21
   arm64-darwin-23
-  x86_64-linux
   ruby
+  x86_64-linux
 
 DEPENDENCIES
 
 BUNDLED WITH
-   2.5.6
+  4.0.10

--- a/solutions/ruby/01-ns2/code/Gemfile.lock
+++ b/solutions/ruby/01-ns2/code/Gemfile.lock
@@ -6,10 +6,10 @@ PLATFORMS
   aarch64-linux-musl
   arm64-darwin-21
   arm64-darwin-23
-  x86_64-linux
   ruby
+  x86_64-linux
 
 DEPENDENCIES
 
 BUNDLED WITH
-   2.5.6
+  4.0.10

--- a/starter_templates/ruby/code/Gemfile.lock
+++ b/starter_templates/ruby/code/Gemfile.lock
@@ -6,10 +6,10 @@ PLATFORMS
   aarch64-linux-musl
   arm64-darwin-21
   arm64-darwin-23
-  x86_64-linux
   ruby
+  x86_64-linux
 
 DEPENDENCIES
 
 BUNDLED WITH
-   2.5.6
+  4.0.10


### PR DESCRIPTION
CC-2191: Upgrade Ruby to v4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only updates that bump the required Bundler version; low risk aside from potential CI/local environment mismatch if Bundler 4 isn’t available.
> 
> **Overview**
> Updates Ruby `Gemfile.lock` files in the starter, template, and solution directories to require **Bundler 4.0.10** (from 2.5.6) and normalizes the `PLATFORMS` list to include `x86_64-linux`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bbb839ced2e49484562070d1e6ecfe5a5a981e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->