### PR TITLE
CC-2208: Upgrade Zig to 0.16

### DIFF
--- a/compiled_starters/zig/README.md
+++ b/compiled_starters/zig/README.md
@@ -27,7 +27,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `zig (0.15)` installed locally
+1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.zig`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/zig/build.zig.zon
+++ b/compiled_starters/zig/build.zig.zon
@@ -8,7 +8,7 @@
 
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/compiled_starters/zig/codecrafters.yml
+++ b/compiled_starters/zig/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Zig version used to run your code
 # on Codecrafters.
 #
-# Available versions: zig-0.15.2
-buildpack: zig-0.15.2
+# Available versions: zig-0.16
+buildpack: zig-0.16

--- a/compiled_starters/zig/src/main.zig
+++ b/compiled_starters/zig/src/main.zig
@@ -1,16 +1,13 @@
 const std = @import("std");
 
-pub fn main() !void {
-    const allocator = std.heap.page_allocator;
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
+pub fn main(init: std.process.Init) !void {
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
 
-    var stdout_buffer: [1024]u8 = undefined;
-    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
-    const stdout = &stdout_writer.interface;
+    var stdout = std.Io.File.stdout().writer(init.io, &.{});
+    var stderr = std.Io.File.stderr().writer(init.io, &.{});
 
     if (args.len < 3) {
-        try stdout.writeAll("Usage: your_program.sh <command> <args>\n");
+        try stdout.interface.print("Usage: your_program.sh <command> <args>\n", .{});
         std.process.exit(1);
     }
 
@@ -18,19 +15,18 @@ pub fn main() !void {
 
     if (std.mem.eql(u8, command, "decode")) {
         // You can use print statements as follows for debugging, they'll be visible when running tests.
-        std.debug.print("Logs from your program will appear here\n", .{});
+        try stderr.interface.print("Logs from your program will appear here\n", .{});
 
         // TODO: Uncomment the code below to pass the first stage
         //
         // const encodedStr = args[2];
         // const decodedStr = decodeBencode(encodedStr) catch {
-        //     std.debug.print("Invalid encoded value\n", .{});
+        //     try stderr.interface.print("Invalid encoded value\n", .{});
         //     std.process.exit(1);
         // };
-        // var stringify = std.json.Stringify{ .writer = stdout };
+        // var stringify = std.json.Stringify{ .writer = &stdout.interface };
         // try stringify.write(decodedStr);
-        // try stdout.writeAll("\n");
-        // try stdout.flush();
+        // try stdout.interface.print("\n", .{});
     }
 }
 
@@ -42,7 +38,7 @@ fn decodeBencode(encodedValue: []const u8) ![]const u8 {
         }
         return encodedValue[firstColon.? + 1 ..];
     } else {
-        std.debug.print("Only strings are supported at the moment\n", .{});
+        // Only strings are supported at the moment
         std.process.exit(1);
     }
 }

--- a/dockerfiles/zig-0.16.Dockerfile
+++ b/dockerfiles/zig-0.16.Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM debian:trixie
+
+# hadolint ignore=DL3008
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        curl \
+        xz-utils \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Download and install Zig
+RUN curl -O https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz \
+    && tar -xf zig-x86_64-linux-0.16.0.tar.xz \
+    && mv zig-x86_64-linux-0.16.0 /usr/local/zig \
+    && rm zig-x86_64-linux-0.16.0.tar.xz
+
+# Add Zig to PATH
+ENV PATH="/usr/local/zig:${PATH}"
+
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="build.zig,build.zig.zon"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs zig build
+RUN .codecrafters/compile.sh
+
+# Cache build directory
+RUN mkdir -p /app-cached
+RUN mv /app/.zig-cache /app-cached/.zig-cache || true

--- a/solutions/zig/01-ns2/code/README.md
+++ b/solutions/zig/01-ns2/code/README.md
@@ -27,7 +27,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `zig (0.15)` installed locally
+1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.zig`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/zig/01-ns2/code/build.zig.zon
+++ b/solutions/zig/01-ns2/code/build.zig.zon
@@ -8,7 +8,7 @@
 
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/solutions/zig/01-ns2/code/codecrafters.yml
+++ b/solutions/zig/01-ns2/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Zig version used to run your code
 # on Codecrafters.
 #
-# Available versions: zig-0.15.2
-buildpack: zig-0.15.2
+# Available versions: zig-0.16
+buildpack: zig-0.16

--- a/solutions/zig/01-ns2/code/src/main.zig
+++ b/solutions/zig/01-ns2/code/src/main.zig
@@ -1,16 +1,13 @@
 const std = @import("std");
 
-pub fn main() !void {
-    const allocator = std.heap.page_allocator;
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
+pub fn main(init: std.process.Init) !void {
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
 
-    var stdout_buffer: [1024]u8 = undefined;
-    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
-    const stdout = &stdout_writer.interface;
+    var stdout = std.Io.File.stdout().writer(init.io, &.{});
+    var stderr = std.Io.File.stderr().writer(init.io, &.{});
 
     if (args.len < 3) {
-        try stdout.writeAll("Usage: your_program.sh <command> <args>\n");
+        try stdout.interface.print("Usage: your_program.sh <command> <args>\n", .{});
         std.process.exit(1);
     }
 
@@ -19,13 +16,12 @@ pub fn main() !void {
     if (std.mem.eql(u8, command, "decode")) {
         const encodedStr = args[2];
         const decodedStr = decodeBencode(encodedStr) catch {
-            std.debug.print("Invalid encoded value\n", .{});
+            try stderr.interface.print("Invalid encoded value\n", .{});
             std.process.exit(1);
         };
-        var stringify = std.json.Stringify{ .writer = stdout };
+        var stringify = std.json.Stringify{ .writer = &stdout.interface };
         try stringify.write(decodedStr);
-        try stdout.writeAll("\n");
-        try stdout.flush();
+        try stdout.interface.print("\n", .{});
     }
 }
 
@@ -37,7 +33,7 @@ fn decodeBencode(encodedValue: []const u8) ![]const u8 {
         }
         return encodedValue[firstColon.? + 1 ..];
     } else {
-        std.debug.print("Only strings are supported at the moment\n", .{});
+        // Only strings are supported at the moment
         std.process.exit(1);
     }
 }

--- a/solutions/zig/01-ns2/diff/src/main.zig.diff
+++ b/solutions/zig/01-ns2/diff/src/main.zig.diff
@@ -1,17 +1,14 @@
-@@ -1,48 +1,43 @@
+@@ -1,44 +1,39 @@
  const std = @import("std");
 
- pub fn main() !void {
-     const allocator = std.heap.page_allocator;
-     const args = try std.process.argsAlloc(allocator);
-     defer std.process.argsFree(allocator, args);
+ pub fn main(init: std.process.Init) !void {
+     const args = try init.minimal.args.toSlice(init.arena.allocator());
 
-     var stdout_buffer: [1024]u8 = undefined;
-     var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
-     const stdout = &stdout_writer.interface;
+     var stdout = std.Io.File.stdout().writer(init.io, &.{});
+     var stderr = std.Io.File.stderr().writer(init.io, &.{});
 
      if (args.len < 3) {
-         try stdout.writeAll("Usage: your_program.sh <command> <args>\n");
+         try stdout.interface.print("Usage: your_program.sh <command> <args>\n", .{});
          std.process.exit(1);
      }
 
@@ -19,28 +16,26 @@
 
      if (std.mem.eql(u8, command, "decode")) {
 -        // You can use print statements as follows for debugging, they'll be visible when running tests.
--        std.debug.print("Logs from your program will appear here\n", .{});
+-        try stderr.interface.print("Logs from your program will appear here\n", .{});
 -
 -        // TODO: Uncomment the code below to pass the first stage
 -        //
 -        // const encodedStr = args[2];
 -        // const decodedStr = decodeBencode(encodedStr) catch {
--        //     std.debug.print("Invalid encoded value\n", .{});
+-        //     try stderr.interface.print("Invalid encoded value\n", .{});
 -        //     std.process.exit(1);
 -        // };
--        // var stringify = std.json.Stringify{ .writer = stdout };
+-        // var stringify = std.json.Stringify{ .writer = &stdout.interface };
 -        // try stringify.write(decodedStr);
--        // try stdout.writeAll("\n");
--        // try stdout.flush();
+-        // try stdout.interface.print("\n", .{});
 +        const encodedStr = args[2];
 +        const decodedStr = decodeBencode(encodedStr) catch {
-+            std.debug.print("Invalid encoded value\n", .{});
++            try stderr.interface.print("Invalid encoded value\n", .{});
 +            std.process.exit(1);
 +        };
-+        var stringify = std.json.Stringify{ .writer = stdout };
++        var stringify = std.json.Stringify{ .writer = &stdout.interface };
 +        try stringify.write(decodedStr);
-+        try stdout.writeAll("\n");
-+        try stdout.flush();
++        try stdout.interface.print("\n", .{});
      }
  }
 
@@ -52,7 +47,7 @@
          }
          return encodedValue[firstColon.? + 1 ..];
      } else {
-         std.debug.print("Only strings are supported at the moment\n", .{});
+         // Only strings are supported at the moment
          std.process.exit(1);
      }
  }

--- a/starter_templates/zig/code/build.zig.zon
+++ b/starter_templates/zig/code/build.zig.zon
@@ -8,7 +8,7 @@
 
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/starter_templates/zig/code/src/main.zig
+++ b/starter_templates/zig/code/src/main.zig
@@ -1,16 +1,13 @@
 const std = @import("std");
 
-pub fn main() !void {
-    const allocator = std.heap.page_allocator;
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
+pub fn main(init: std.process.Init) !void {
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
 
-    var stdout_buffer: [1024]u8 = undefined;
-    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
-    const stdout = &stdout_writer.interface;
+    var stdout = std.Io.File.stdout().writer(init.io, &.{});
+    var stderr = std.Io.File.stderr().writer(init.io, &.{});
 
     if (args.len < 3) {
-        try stdout.writeAll("Usage: your_program.sh <command> <args>\n");
+        try stdout.interface.print("Usage: your_program.sh <command> <args>\n", .{});
         std.process.exit(1);
     }
 
@@ -18,19 +15,18 @@ pub fn main() !void {
 
     if (std.mem.eql(u8, command, "decode")) {
         // You can use print statements as follows for debugging, they'll be visible when running tests.
-        std.debug.print("Logs from your program will appear here\n", .{});
+        try stderr.interface.print("Logs from your program will appear here\n", .{});
 
         // TODO: Uncomment the code below to pass the first stage
         //
         // const encodedStr = args[2];
         // const decodedStr = decodeBencode(encodedStr) catch {
-        //     std.debug.print("Invalid encoded value\n", .{});
+        //     try stderr.interface.print("Invalid encoded value\n", .{});
         //     std.process.exit(1);
         // };
-        // var stringify = std.json.Stringify{ .writer = stdout };
+        // var stringify = std.json.Stringify{ .writer = &stdout.interface };
         // try stringify.write(decodedStr);
-        // try stdout.writeAll("\n");
-        // try stdout.flush();
+        // try stdout.interface.print("\n", .{});
     }
 }
 
@@ -42,7 +38,7 @@ fn decodeBencode(encodedValue: []const u8) ![]const u8 {
         }
         return encodedValue[firstColon.? + 1 ..];
     } else {
-        std.debug.print("Only strings are supported at the moment\n", .{});
+        // Only strings are supported at the moment
         std.process.exit(1);
     }
 }

--- a/starter_templates/zig/config.yml
+++ b/starter_templates/zig/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: zig (0.15)
+  required_executable: zig (0.16)
   user_editable_file: src/main.zig


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it upgrades the Zig toolchain and updates starter code to new `std.process`/I/O APIs, which could break builds or runtime behavior if any remaining code relies on 0.15 semantics.
> 
> **Overview**
> Upgrades the Zig BitTorrent starter/solution templates and CodeCrafters buildpack from **Zig 0.15** to **Zig 0.16** (docs, `build.zig.zon` minimum version, and `codecrafters.yml`).
> 
> Updates the Zig starter `main.zig` entrypoint to the Zig 0.16 `std.process.Init` signature and switches stdout/stderr printing to the new `std.Io.File.*.writer`/`.interface.print` APIs.
> 
> Adds a new `dockerfiles/zig-0.16.Dockerfile` that installs Zig 0.16.0 and runs the compile step during image build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3b16271cc2025ea64af9d3278c34ab2389f8be8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->