### PR TITLE
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

### DIFF
--- a/compiled_starters/c/README.md
+++ b/compiled_starters/c/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `src/main.c`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.c`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/cpp/README.md
+++ b/compiled_starters/cpp/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `src/main.cpp`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.cpp`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/csharp/README.md
+++ b/compiled_starters/csharp/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `src/Program.cs`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dotnet (9.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/Program.cs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/elixir/README.md
+++ b/compiled_starters/elixir/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `lib/main.ex`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mix` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `lib/main.ex`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/go/README.md
+++ b/compiled_starters/go/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `app/main.go`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `go (1.26)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.go`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/haskell/README.md
+++ b/compiled_starters/haskell/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `app/Main.hs`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `stack (23.18)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/Main.hs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/java/README.md
+++ b/compiled_starters/java/README.md
@@ -14,12 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in
-`src/main/java/Main.java`. Study and uncomment the relevant code, and push your
-changes to pass the first stage:
+`src/main/java/Main.java`. Study and uncomment the relevant code, then run the
+command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -31,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mvn` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main/java/Main.java`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/javascript/README.md
+++ b/compiled_starters/javascript/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `app/main.js`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `node (25)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.js`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/kotlin/README.md
+++ b/compiled_starters/kotlin/README.md
@@ -14,12 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in
-`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and push
-your changes to pass the first stage:
+`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, then run
+the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -31,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gradle (9.4.1)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/src/main/kotlin/App.kt`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/python/README.md
+++ b/compiled_starters/python/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `app/main.py`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `uv` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.py`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/ruby/README.md
+++ b/compiled_starters/ruby/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `app/main.rb`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `ruby (4.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.rb`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `src/main.rs`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -31,5 +31,5 @@ Note: This section is for stages 2 and beyond.
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/scala/README.md
+++ b/compiled_starters/scala/README.md
@@ -15,11 +15,10 @@ Protocol, pipelining and more.
 
 The entry point for your BitTorrent implementation is in
 `src/main/scala/codecrafters_bittorrent/App.scala`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, then run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -31,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `scala-cli` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main/scala/codecrafters_bittorrent/App.scala`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/typescript/README.md
+++ b/compiled_starters/typescript/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `app/main.ts`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `bun (1.3)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.ts`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/compiled_starters/zig/README.md
+++ b/compiled_starters/zig/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `src/main.zig`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.zig`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/c/01-ns2/code/README.md
+++ b/solutions/c/01-ns2/code/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `src/main.c`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, then run the command below to execute the tests on
+our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.c`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/cpp/01-ns2/code/README.md
+++ b/solutions/cpp/01-ns2/code/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `src/main.cpp`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.cpp`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/csharp/01-ns2/code/README.md
+++ b/solutions/csharp/01-ns2/code/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `src/Program.cs`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dotnet (9.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/Program.cs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/elixir/01-ns2/code/README.md
+++ b/solutions/elixir/01-ns2/code/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `lib/main.ex`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mix` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `lib/main.ex`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/go/01-ns2/code/README.md
+++ b/solutions/go/01-ns2/code/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `app/main.go`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `go (1.26)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.go`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/haskell/01-ns2/code/README.md
+++ b/solutions/haskell/01-ns2/code/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `app/Main.hs`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `stack (23.18)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/Main.hs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/java/01-ns2/code/README.md
+++ b/solutions/java/01-ns2/code/README.md
@@ -14,12 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in
-`src/main/java/Main.java`. Study and uncomment the relevant code, and push your
-changes to pass the first stage:
+`src/main/java/Main.java`. Study and uncomment the relevant code, then run the
+command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -31,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mvn` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main/java/Main.java`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/javascript/01-ns2/code/README.md
+++ b/solutions/javascript/01-ns2/code/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `app/main.js`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `node (25)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.js`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/kotlin/01-ns2/code/README.md
+++ b/solutions/kotlin/01-ns2/code/README.md
@@ -14,12 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in
-`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and push
-your changes to pass the first stage:
+`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, then run
+the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -31,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gradle (9.4.1)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/src/main/kotlin/App.kt`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/python/01-ns2/code/README.md
+++ b/solutions/python/01-ns2/code/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `app/main.py`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `uv` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.py`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/ruby/01-ns2/code/README.md
+++ b/solutions/ruby/01-ns2/code/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `app/main.rb`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `ruby (4.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.rb`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/rust/01-ns2/code/README.md
+++ b/solutions/rust/01-ns2/code/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `src/main.rs`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -31,5 +31,5 @@ Note: This section is for stages 2 and beyond.
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/scala/01-ns2/code/README.md
+++ b/solutions/scala/01-ns2/code/README.md
@@ -15,11 +15,10 @@ Protocol, pipelining and more.
 
 The entry point for your BitTorrent implementation is in
 `src/main/scala/codecrafters_bittorrent/App.scala`. Study and uncomment the
-relevant code, and push your changes to pass the first stage:
+relevant code, then run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -31,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `scala-cli` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main/scala/codecrafters_bittorrent/App.scala`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/typescript/01-ns2/code/README.md
+++ b/solutions/typescript/01-ns2/code/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `app/main.ts`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `bun (1.3)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.ts`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/solutions/zig/01-ns2/code/README.md
+++ b/solutions/zig/01-ns2/code/README.md
@@ -14,11 +14,11 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in `src/main.zig`. Study
-and uncomment the relevant code, and push your changes to pass the first stage:
+and uncomment the relevant code, then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -30,5 +30,5 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.zig`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.

--- a/starter_templates/all/code/README.md
+++ b/starter_templates/all/code/README.md
@@ -14,12 +14,10 @@ Protocol, pipelining and more.
 # Passing the first stage
 
 The entry point for your BitTorrent implementation is in
-`{{ user_editable_file }}`. Study and uncomment the relevant code, and push your
-changes to pass the first stage:
+`{{ user_editable_file }}`. Study and uncomment the relevant code, then run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!
@@ -33,5 +31,4 @@ Note: This section is for stages 2 and beyond.
    `{{ user_editable_file }}`.{{# language_is_rust }} This command compiles your
    Rust project, so it might be slow the first time you run it. Subsequent runs
    will be fast.{{/ language_is_rust}}
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test output will be streamed to your terminal.


### PR DESCRIPTION
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates contributor instructions without affecting runtime code or build behavior.
> 
> **Overview**
> Updates the BitTorrent challenge README submission instructions across all compiled starters, solution snapshots, and the shared `starter_templates/all/code/README.md` template to use `codecrafters submit` instead of `git commit`/`git push`.
> 
> Also tweaks the first-stage wording to clarify that `codecrafters submit` runs tests on CodeCrafters servers and streams the output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6503e6b869010fdcafb46a89d6179a36b119141. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->